### PR TITLE
More Unit Test fixes

### DIFF
--- a/LockCheck.sln
+++ b/LockCheck.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LockCheck", "src\LockCheck\LockCheck.csproj", "{CC3BF24A-0A94-4655-A3EF-A722974F0872}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7866B6F0-7EDD-450D-9674-34C69C96CE23}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "(root)", "(root)", "{7866B6F0-7EDD-450D-9674-34C69C96CE23}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
@@ -37,6 +37,17 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LCTestTarget.win-x64", "test\LCTestTarget.win-x64\LCTestTarget.win-x64.csproj", "{4A4981CF-FA1C-4D38-A39D-8F7AD1356151}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{970DB648-53EB-435B-9A8F-4BFFCA92A54B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{8D00B1B0-9527-4D0A-A259-77B86F4A6F00}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{734C8779-B662-4F7F-91E4-4DB6E1436BB0}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet-reusable-workflow.yml = .github\workflows\dotnet-reusable-workflow.yml
+		.github\workflows\dotnet-ubuntu.yml = .github\workflows\dotnet-ubuntu.yml
+		.github\workflows\dotnet-windows.yml = .github\workflows\dotnet-windows.yml
+		.github\workflows\update_gist.sh = .github\workflows\update_gist.sh
+		.github\workflows\upload-coverage-report.yml = .github\workflows\upload-coverage-report.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -85,6 +96,8 @@ Global
 		{F0279C06-9D4E-40D8-A569-3DFEB9926CD2} = {018E2998-2375-4819-9B5A-554C4F46BC1F}
 		{E7A79EE4-7331-4B50-A191-6F16C621F80C} = {018E2998-2375-4819-9B5A-554C4F46BC1F}
 		{4A4981CF-FA1C-4D38-A39D-8F7AD1356151} = {018E2998-2375-4819-9B5A-554C4F46BC1F}
+		{8D00B1B0-9527-4D0A-A259-77B86F4A6F00} = {7866B6F0-7EDD-450D-9674-34C69C96CE23}
+		{734C8779-B662-4F7F-91E4-4DB6E1436BB0} = {8D00B1B0-9527-4D0A-A259-77B86F4A6F00}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9EFF99EA-5D9E-48B7-A277-E477BD55F517}

--- a/src/LockCheck/CodeAnalysisShim.cs
+++ b/src/LockCheck/CodeAnalysisShim.cs
@@ -1,0 +1,36 @@
+#if NETFRAMEWORK
+
+// Some attribute definitions that are not available on .NET Framework.
+// Add additional ones as required.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+     /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/test/LockCheck.Tests/ExceptionUtilsTests.cs
+++ b/test/LockCheck.Tests/ExceptionUtilsTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using LockCheck.Tests.Tooling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LockCheck.Tests

--- a/test/LockCheck.Tests/IJobObject.cs
+++ b/test/LockCheck.Tests/IJobObject.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using LockCheck.Tests.Windows;
+
+namespace LockCheck.Tests
+{
+    internal interface IJobObject : IDisposable
+    {
+        void AttachProcess(Process process);
+    }
+
+    internal static class JobObject
+    {
+        // Provide a toggle to generally disable job objects - whether supported by the platform or not.
+        // This can be used in situations where they might cause issues (due to permissions, etc.).
+        private static readonly bool s_disabled = Environment.GetEnvironmentVariable("LOCKCHECK_DISABLE_JOBOBJECT") == "true";
+
+        public static IJobObject Create(string? name = null)
+        {
+            if (!s_disabled)
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return new Win32JobObject(name);
+                }
+            }
+
+            return new NoopJobObject();
+        }
+
+        private class NoopJobObject : IJobObject
+        {
+            public void AttachProcess(Process process)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/LockCheck.Tests/Linux/ProcFileSystemTests.cs
+++ b/test/LockCheck.Tests/Linux/ProcFileSystemTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Text;
 using LockCheck.Linux;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,25 +12,9 @@ namespace LockCheck.Tests.Linux
         [TestMethod]
         public void GetProcessExecutablePathFromCmdLine_ShouldReturnExecutableName_WhenNoPermissionToProcess()
         {
-            using var init = Process.GetProcessById(1);
-
-            // This check will only work with "official" Microsoft images.
-            if (Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true")
-            {
-                // Running inside a container, PID 1 will not be /sbin/init, but the process that was
-                // initially started in the container.
-                Assert.IsNotNull(init.MainModule);
-                // MainModule.FileName might just be the file name, not the full path, as documented.
-                StringAssert.Contains(init.MainModule!.FileName, ProcFileSystem.GetProcessExecutablePathFromCmdLine(1));
-            }
-            else
-            {
-                // Not running in a container, PID 1 is the init process.
-                // MainModule should be null, because we expect the unit tests to not run as root and thus
-                // don't have permissions to access details of the process.
-                Assert.IsNull(init.MainModule);
-                Assert.AreEqual("/sbin/init", ProcFileSystem.GetProcessExecutablePathFromCmdLine(1));
-            }
+            using var self = Process.GetCurrentProcess();
+            Assert.IsNotNull(self.MainModule, "No permissions to current process");
+            StringAssert.Contains(self.MainModule!.FileName, ProcFileSystem.GetProcessExecutablePathFromCmdLine(self.Id));
         }
 
         [TestMethod]

--- a/test/LockCheck.Tests/Linux/ProcFileSystemTests.cs
+++ b/test/LockCheck.Tests/Linux/ProcFileSystemTests.cs
@@ -2,11 +2,13 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using LockCheck.Linux;
+using LockCheck.Tests.Tooling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LockCheck.Tests.Linux
 {
     [SupportedTestClassPlatform("linux")]
+    [TestCategory("linux")]
     public partial class ProcFileSystemTests
     {
         [TestMethod]

--- a/test/LockCheck.Tests/LockCheck.Tests.csproj
+++ b/test/LockCheck.Tests/LockCheck.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/LockCheck.Tests/LockCheck.Tests.csproj
+++ b/test/LockCheck.Tests/LockCheck.Tests.csproj
@@ -19,7 +19,7 @@
   supported on Linux anyway, and this safes us some #if/#endif juggling in the Linux
   sources. -->
   <ItemGroup Condition="'$(IsNetFramework)' == 'true'">
-    <Compile Remove="Linux/**/*.cs"/>
+    <Compile Remove="Linux/**/*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LockCheck.Tests/LockManagerTests.cs
+++ b/test/LockCheck.Tests/LockManagerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using LockCheck.Tests.Tooling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LockCheck.Tests

--- a/test/LockCheck.Tests/TestHelper.cs
+++ b/test/LockCheck.Tests/TestHelper.cs
@@ -74,6 +74,10 @@ namespace LockCheck.Tests
             }
         }
 
+        // Assign all child processes we launch to this job object. This ensures that they
+        // will get terminated at the very least, when the test (testhost.exe) itself exits.
+        private static readonly Lazy<IJobObject> s_selfJob = new(() => JobObject.Create(), LazyThreadSafetyMode.ExecutionAndPublication);
+
         public static void CreateProcessWithCurrentDirectory(
             bool target64Bit,
             Action<(string TemporaryDirectory, int ProcessId, int SessionId, DateTime ProcessStartTime, string ProcessName, string ExecutableFullPath)> action)
@@ -132,6 +136,8 @@ namespace LockCheck.Tests
                 {
                     throw new InvalidOperationException($"Failed to start test target: {si.FileName} {si.Arguments}");
                 }
+
+                s_selfJob.Value.AttachProcess(process);
 
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
@@ -280,6 +286,8 @@ namespace LockCheck.Tests
                 {
                     throw new InvalidOperationException($"Failed to start process: {si.FileName} {si.Arguments}");
                 }
+
+                s_selfJob.Value.AttachProcess(process);
 
                 process.BeginOutputReadLine();
 

--- a/test/LockCheck.Tests/TestHelperTests.cs
+++ b/test/LockCheck.Tests/TestHelperTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using LockCheck.Tests.Tooling;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LockCheck.Tests
+{
+    [TestClass]
+    public class TestHelperTests
+    {
+        [DataTestMethod]
+        [DataRow("usr/local/bin", "usr", "", true)]
+        [DataRow("/usr/local/bin", "usr", "/", true)]
+        [DataRow("/usr/local/bin", "local", "/usr/", true)]
+        [DataRow("/usr/local/bin/local/foo", "local", "/usr/local/bin/", true)]
+        [DataRow("/usr/local/bin", "bin", "/usr/local/", true)]
+        [DataRow("/usr/local/bin", "loc", null, false)]
+        [DataRow("/usr/local/bin", "localX", null, false)]
+        [DataRow("/usr/local/bin", "binXX", null, false)]
+        [DataRow("\\Users\\Homer\\Documents", "Users", "\\", true)]
+        [DataRow("Users\\Homer\\Documents", "Users", "", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "C:", "", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "Users", "C:\\", true)]
+        [DataRow("C:\\Users\\Homer\\Documents\\Users\\Foo", "Users", "C:\\Users\\Homer\\Documents\\", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "Homer", "C:\\Users\\", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "Documents", "C:\\Users\\Homer\\", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "Ho", null, false)]
+        [DataRow("C:\\Users\\Homer\\Documents", "HomerX", null, false)]
+        [DataRow("C:\\Users\\Homer\\Documents", "DocumentsXX", null, false)]
+        public void TryGetPathBeforeLastSegment(string path, string segment, string expectedPrefix, bool expectedResult)
+        {
+            bool result = TestHelper.TryGetPathBeforeLastSegment(path, segment, out var prefix);
+
+            Assert.AreEqual(expectedResult, result);
+            Assert.AreEqual(expectedPrefix, prefix);
+        }
+
+        [DataTestMethod]
+        [DataRow("/usr/local/bin", "usr", "/local/bin", true)]
+        [DataRow("/usr/local/bin", "local", "/bin", true)]
+        [DataRow("/usr/local/bin", "bin", "", true)]
+        [DataRow("/usr/local/bin/local/foo", "local", "/foo", true)]
+        [DataRow("/usr/local/bin", "loc", null, false)]
+        [DataRow("/usr/local/bin", "localX", null, false)]
+        [DataRow("/usr/local/bin", "binXX", null, false)]
+        [DataRow("C:\\Users\\Homer\\Documents", "Users", "\\Homer\\Documents", true)]
+        [DataRow("\\Users\\Homer\\Documents", "Users", "\\Homer\\Documents", true)]
+        [DataRow("Users\\Homer\\Documents", "Users", "\\Homer\\Documents", true)]
+        [DataRow("Users\\Homer\\Documents", "Documents", "", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "C:", "\\Users\\Homer\\Documents", true)]
+        [DataRow("C:\\Users\\Homer\\Documents\\Users\\Foo", "Users", "\\Foo", true)]
+        [DataRow("C:\\Users\\Homer\\Documents", "Ho", null, false)]
+        [DataRow("C:\\Users\\Homer\\Documents", "HomerX", null, false)]
+        [DataRow("C:\\Users\\Homer\\Documents", "DocumentsXX", null, false)]
+        public void TryGetPathAfterLastSegment(string path, string segment, string expectedSuffix, bool expectedResult)
+        {
+            bool result = TestHelper.TryGetPathAfterLastSegment(path, segment, out var suffix);
+
+            Assert.AreEqual(expectedResult, result);
+            Assert.AreEqual(expectedSuffix, suffix);
+        }
+    }
+}

--- a/test/LockCheck.Tests/Tooling/IJobObject.cs
+++ b/test/LockCheck.Tests/Tooling/IJobObject.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using LockCheck.Tests.Windows;
 
-namespace LockCheck.Tests
+namespace LockCheck.Tests.Tooling
 {
     internal interface IJobObject : IDisposable
     {

--- a/test/LockCheck.Tests/Tooling/SupportedTestClassPlatformAttribute.cs
+++ b/test/LockCheck.Tests/Tooling/SupportedTestClassPlatformAttribute.cs
@@ -1,0 +1,27 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LockCheck.Tests.Tooling
+{
+    /// <summary>
+    /// Only executes test in the test class that match the given test platform.
+    /// </summary>
+    public sealed class SupportedTestClassPlatformAttribute : TestClassAttribute
+    {
+        public SupportedTestClassPlatformAttribute(string platformName)
+        {
+            PlatformName = platformName;
+        }
+
+        public string PlatformName { get; }
+
+        public override TestMethodAttribute? GetTestMethodAttribute(TestMethodAttribute? testMethodAttribute)
+        {
+            if (testMethodAttribute is SupportedTestMethodPlatformAttribute ta)
+            {
+                return ta;
+            }
+
+            return new SupportedTestMethodPlatformAttribute(base.GetTestMethodAttribute(testMethodAttribute), PlatformName.ToString());
+        }
+    }
+}

--- a/test/LockCheck.Tests/Tooling/TestHelper.cs
+++ b/test/LockCheck.Tests/Tooling/TestHelper.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Diagnostics;
-using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
@@ -8,30 +8,26 @@ using System.Threading;
 using LockCheck.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace LockCheck.Tests
+namespace LockCheck.Tests.Tooling
 {
     internal static class TestHelper
     {
-        public static void RunWithInvariantCulture(Action action)
-            => RunWithCulture(CultureInfo.InvariantCulture, action);
-
-        public static void RunWithCulture(CultureInfo cultureInfo, Action action)
+        public static void TryDelete(this FileSystemInfo fi)
         {
-            var oldUi = CultureInfo.CurrentUICulture;
-            var old = CultureInfo.CurrentCulture;
             try
             {
-                CultureInfo.CurrentUICulture = cultureInfo;
-                CultureInfo.CurrentCulture = cultureInfo;
-
-                action();
+                fi?.Delete();
             }
-            finally
+            catch (Exception ex)
             {
-                CultureInfo.CurrentUICulture = oldUi;
-                CultureInfo.CurrentCulture = old;
+                // This can be a test (logic) error. Or temporary lock situation was not
+                // properly resolved before attempting to delete the file/directory.
+                // In either case we do not throw this onward because it could hide
+                // an actual Assert-failure.
+                Console.WriteLine($"WARNING: Could not delete '{fi.FullName}': {ex}");
             }
         }
+
 
         public static NativeMethods.FILETIME ToNativeFileTime(this DateTime dateTime)
         {
@@ -67,10 +63,7 @@ namespace LockCheck.Tests
             }
             finally
             {
-                if (File.Exists(tempFile))
-                {
-                    File.Delete(tempFile);
-                }
+                new FileInfo(tempFile).TryDelete();
             }
         }
 
@@ -179,24 +172,24 @@ namespace LockCheck.Tests
                     process?.Dispose();
                 }
 
-                tempDir.Delete();
+                tempDir.TryDelete();
             }
         }
 
         private static string GetClientFullPath(bool target64Bit, out string? hostExecutable)
         {
-            string runtimeIdentifier;
+            string targetRid;
             string extension;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                runtimeIdentifier = target64Bit ? "win-x64" : "win-x86";
+                targetRid = target64Bit ? "win-x64" : "win-x86";
                 extension = ".exe";
                 hostExecutable = null;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                runtimeIdentifier = "linux-x64";
+                targetRid = "linux-x64";
                 extension = ".dll";
                 hostExecutable = "/usr/share/dotnet/dotnet";
             }
@@ -205,35 +198,67 @@ namespace LockCheck.Tests
                 throw new PlatformNotSupportedException();
             }
 
-            // Assume the following directory structure:
+            // Attempt to locate the LCTestTarget binary for the given TargetRID.
             //
-            //    test\LockCheck.Tests\bin\<Configuration>\<TargetFramework>
-            //    test\LCTestTarget.<RID>\bin\<Configuration>\<TargetFramework>\<RID>\LCTestTarget<EXTENSION>
+            // Assume that LockCheck.Tests (this assembly) is located as follows:
             //
-            // Obviously, this would have to change if your directory layout changes (e.g. using ArtifactPath in MSBUILD).
-            // But that would cause pretty obvious test failures and diagnosing them, will end looking here anyway.
+            //       C:\...\test\LockCheck.Tests\bin\<Configuration>\<TargetFramework>[\<RID>]   (=> AppContext.BaseDirectory)
+            //
+            // Note that sometimes this path ends with the RID, sometimes it doesn't. That depends
+            // on how the build/tests are invoked. So we have to cater for both possibilities.
+            //
+            // Assume further, that LCTestTarget projects are located as follows:
+            //
+            //       C:\...\test\LCTestTarget.<TargetRID>\bin\<Configuration>\<TargetFramework>\<TargetRid>\LCTestTarget<Extension>
+            //
+            // So, we want to run LCTestTarget from the same <TargetFramework> and <Configuration> as this assembly,
+            // but obviously using the <TargetRid> requested.
 
-            var myDir = AppContext.BaseDirectory.AsSpan().TrimEnd('\\').TrimEnd('/');
-            int pos = myDir.LastIndexOfAny(['/', '\\']);
+            ReadOnlySpan<char> separators = ['/', '\\'];
+
+            // Assume that the project (directory name) matches the assembly name.
+            string projectName = typeof(TestHelper).Assembly.GetName().Name!;
+
+            // Get the part of the path before the project directory (e.g. "C:\...\test")
+            if (!TryGetPathBeforeLastSegment(AppContext.BaseDirectory, projectName, out var baseDir))
+            {
+                throw new InvalidOperationException($"Failed to get project base directory from '{AppContext.BaseDirectory}' and '{projectName}'.");
+            }
+
+            // Get the part of the path after the project directory (e.g. "\bin\<Configuration>\<TargetFramework>[\<RID>]")
+            if (!TryGetPathAfterLastSegment(AppContext.BaseDirectory, projectName, out var outputDirString))
+            {
+                throw new InvalidOperationException($"Failed to get output directory from '{AppContext.BaseDirectory}' and '{projectName}'.");
+            }
+
+            // See if the path after the project directory ends with the RID (of this assembly)..
+            var outputDir = outputDirString.AsSpan().Trim(separators);
+            var currentRid = GetCurrentRuntimeIdentifier().AsSpan();
+            if (outputDir.ToString().EndsWith(currentRid.ToString()))
+            {
+                // Remove the RID from the path, so that next we can always assume the same segment
+                // position for <Configuration> and <TargetFramework>.
+                outputDir = outputDir.Slice(0, outputDir.Length - currentRid.Length).Trim(separators);
+            }
+
+            // Now, outputDir should look like this bin\<Configuration>\<TargetFramework>
+            int pos = outputDir.LastIndexOfAny(separators);
             Debug.Assert(pos != -1);
-            var targetFramework = myDir.Slice(pos + 1);
-            myDir = myDir.Slice(0, pos);
-            pos = myDir.LastIndexOfAny(['/', '\\']);
-            var configuration = myDir.Slice(pos + 1);
+            var targetFramework = outputDir.Slice(pos + 1);
+            outputDir = outputDir.Slice(0, pos).Trim(separators);
+            pos = outputDir.LastIndexOfAny(separators);
+            var configuration = outputDir.Slice(pos + 1);
 
-            string clientFullPath = Path.GetFullPath(
-                Path.Combine(
-                    AppContext.BaseDirectory, // in TargetFramework
-                    "..", // in Configuration
-                    "..", // in bin
-                    "..", // in "LockCheck.Tests"
-                    "..", // in "test"
-                    $@"LCTestTarget.{runtimeIdentifier}",
-                    "bin",
-                    configuration.ToString(),
-                    targetFramework.ToString(),
-                    runtimeIdentifier,
-                    $"LCTestTarget{extension}"));
+            string clientFullPath = Path.Combine(
+                baseDir.ToString(),
+                $"LCTestTarget.{targetRid}",
+                "bin",
+                configuration.ToString(),
+                targetFramework.ToString(),
+                targetRid,
+                $"LCTestTarget{extension}");
+
+            clientFullPath = Path.GetFullPath(clientFullPath);
             return clientFullPath;
         }
 
@@ -304,10 +329,10 @@ namespace LockCheck.Tests
             {
                 try
                 {
-                    Console.WriteLine($"KILL IT .... {process?.Id}");
+                    Console.WriteLine($"Killing test target process with process ID {process?.Id} ...");
                     process?.Kill();
                     process?.WaitForExit();
-                    Console.WriteLine("KILLED IT.");
+                    Console.WriteLine("Process killed.");
                 }
                 catch (InvalidOperationException)
                 {
@@ -318,8 +343,113 @@ namespace LockCheck.Tests
                     process?.Dispose();
                 }
 
-                tempDir.Delete();
+                tempDir.TryDelete();
             }
+        }
+
+        /// <summary>
+        /// Get the part of the <paramref name="path"/> before the <i>last</i> occurrence of <paramref name="segment"/>.
+        /// </summary>
+        /// <remarks>
+        /// The specified <paramref name="segment"/> must appear between to directory separator chars (<c>\</c> or <c>/</c>).
+        /// Both are considered on every platform. Partial matches (e.g. "foo" in "/foobar/x") are not considered. Only the
+        /// last occurrence is considered (e.g. "foo" with "/x/foo/bar/foo" sets the prefix to "/x/foo/bar" not "/x/")
+        /// <br/>
+        /// Consider the following:
+        /// <pre>
+        ///   path               segment          prefix
+        ///   /usr/local/bin     usr              "/"
+        ///   usr/local/bin      usr              ""
+        ///   \\User\\Admin      User             "\\"
+        ///   User\\Admin        User             ""
+        ///   C:\\User\\Admin    User             "C:\\"
+        /// </pre>
+        /// </remarks>
+        /// <param name="path"></param>
+        /// <param name="segment"></param>
+        /// <param name="prefix"></param>
+        /// <returns>
+        /// <c>true</c> if <paramref name="segment"/> appears in <paramref name="path"/>.
+        /// <c>false</c> if <paramref name="segment"/> does not appear in <paramref name="path"/>.
+        /// </returns>
+        internal static bool TryGetPathBeforeLastSegment(string path, string segment, [NotNullWhen(true)] out string? prefix)
+        {
+            int index = path.LastIndexOf(segment, StringComparison.Ordinal);
+
+            if (index == -1)
+            {
+                prefix = null;
+                return false;
+            }
+
+            // Check if the segment is at the end or followed by a path separator
+            if (index + segment.Length == path.Length ||
+                path[index + segment.Length] == '\\' ||
+                path[index + segment.Length] == '/')
+            {
+                prefix = path.Substring(0, index);
+                return true;
+            }
+
+            // An actual path segment contains only part of the search segment
+            prefix = null;
+            return false;
+        }
+
+        internal static bool TryGetPathAfterLastSegment(string path, string segment, [NotNullWhen(true)] out string? suffix)
+        {
+            int index = path.LastIndexOf(segment, StringComparison.Ordinal);
+
+            if (index == -1)
+            {
+                suffix = null;
+                return false;
+            }
+
+            // Check if the segment is at the end or followed by a path separator
+            if (index + segment.Length == path.Length ||
+                path[index + segment.Length] == '\\' ||
+                path[index + segment.Length] == '/')
+            {
+                // Calculate the start index of the part after the segment
+                int suffixStartIndex = index + segment.Length;
+
+                // If the suffix starts at the end of the path, return an empty string
+                if (suffixStartIndex >= path.Length)
+                {
+                    suffix = string.Empty;
+                }
+                else
+                {
+                    suffix = path.Substring(suffixStartIndex);
+                }
+
+                return true;
+            }
+
+            // An actual path segment contains only part of the search segment
+            suffix = null;
+            return false;
+        }
+
+        internal static string GetCurrentRuntimeIdentifier()
+        {
+#if NET
+            return RuntimeInformation.RuntimeIdentifier;
+#else
+            // RuntimeInformation.RuntimeIdentifier does not exist in .NET Framework.
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return $"win-{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return $"linux-{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}";
+            }
+
+            throw new InvalidOperationException($"Cannot get RID for '{RuntimeInformation.OSDescription}' and '{RuntimeInformation.ProcessArchitecture}'.");
+#endif
         }
     }
 }

--- a/test/LockCheck.Tests/Windows/NtDllTests.cs
+++ b/test/LockCheck.Tests/Windows/NtDllTests.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using LockCheck.Tests.Tooling;
 using LockCheck.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LockCheck.Tests.Windows
 {
     [SupportedTestClassPlatform("windows")]
+    [TestCategory("windows")]
     public class NtDllTests
     {
         [TestMethod]
@@ -34,7 +36,7 @@ namespace LockCheck.Tests.Windows
             }
             finally
             {
-                di.Delete();
+                di.TryDelete();
             }
         }
 
@@ -55,7 +57,7 @@ namespace LockCheck.Tests.Windows
             }
             finally
             {
-                fi.Delete();
+                fi.TryDelete();
             }
         }
 

--- a/test/LockCheck.Tests/Windows/ProcessInfoWindowsTests.cs
+++ b/test/LockCheck.Tests/Windows/ProcessInfoWindowsTests.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Diagnostics;
+using LockCheck.Tests.Tooling;
 using LockCheck.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LockCheck.Tests.Windows
 {
     [SupportedTestClassPlatform("windows")]
+    [TestCategory("windows")]
     public class ProcessInfoWindowsTests
     {
         [TestMethod]

--- a/test/LockCheck.Tests/Windows/RestartManagerTests.cs
+++ b/test/LockCheck.Tests/Windows/RestartManagerTests.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using LockCheck.Tests.Tooling;
 using LockCheck.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LockCheck.Tests.Windows
 {
     [SupportedTestClassPlatform("windows")]
+    [TestCategory("windows")]
     public class RestartManagerTests
     {
         [TestMethod]
@@ -33,7 +35,7 @@ namespace LockCheck.Tests.Windows
             }
             finally
             {
-                di.Delete();
+                di.TryDelete();
             }
         }
 
@@ -54,7 +56,7 @@ namespace LockCheck.Tests.Windows
             }
             finally
             {
-                fi.Delete();
+                fi.TryDelete();
             }
         }
     }

--- a/test/LockCheck.Tests/Windows/Win32JobObject.cs
+++ b/test/LockCheck.Tests/Windows/Win32JobObject.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using LockCheck.Tests.Tooling;
 using Microsoft.Win32.SafeHandles;
 
 namespace LockCheck.Tests.Windows

--- a/test/LockCheck.Tests/Windows/Win32JobObject.cs
+++ b/test/LockCheck.Tests/Windows/Win32JobObject.cs
@@ -1,0 +1,144 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace LockCheck.Tests.Windows
+{
+    public partial class Win32JobObject : SafeHandleZeroOrMinusOneIsInvalid, IJobObject
+    {
+        private readonly IntPtr _jobHandle;
+
+        public Win32JobObject(string? name)
+            : base(ownsHandle: true)
+        {
+            _jobHandle = CreateJobObject(IntPtr.Zero, name);
+
+            if (_jobHandle == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            SetJobLimits();
+        }
+
+        protected override bool ReleaseHandle() => CloseHandle(_jobHandle);
+
+        private void SetJobLimits()
+        {
+            var basicLimit = new JOBOBJECT_BASIC_LIMIT_INFORMATION { LimitFlags = JOB_OBJECT_LIMIT.KILL_ON_JOB_CLOSE };
+            var extendedLimit = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION { BasicLimitInformation = basicLimit };
+            int extendedLimitSize = Marshal.SizeOf(extendedLimit);
+            IntPtr extendedLimitPtr = IntPtr.Zero;
+            try
+            {
+                extendedLimitPtr = Marshal.AllocHGlobal(extendedLimitSize);
+                Marshal.StructureToPtr(extendedLimit, extendedLimitPtr, false);
+
+                if (!SetInformationJobObject(_jobHandle, JOB_OBJECT_INFO_CLASS.ExtendedLimitInformation, extendedLimitPtr, (uint)extendedLimitSize))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                if (extendedLimitPtr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(extendedLimitPtr);
+                }
+            }
+        }
+
+        public void AttachProcess(Process process)
+        {
+            if (process == null)
+                throw new ArgumentNullException(nameof(process));
+
+            if (!AssignProcessToJobObject(_jobHandle, process.Handle))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+
+        // Native declarations current live here, not in LockCheck/Windows/NativeMethods.cs, because all of the following
+        // is only needed in this class. Which, in turn, is only needed here in LockCheck.Tests.dll.
+
+#if NET
+        [LibraryImport("kernel32.dll", SetLastError = true, EntryPoint = "CreateJobObjectW", StringMarshalling = StringMarshalling.Utf16)]
+        private static partial IntPtr CreateJobObject(IntPtr lpJobAttributes, string? lpName);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool SetInformationJobObject(IntPtr hJob, JOB_OBJECT_INFO_CLASS JobObjectInfoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool CloseHandle(IntPtr hObject);
+#else
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetInformationJobObject(IntPtr hJob, JOB_OBJECT_INFO_CLASS JobObjectInfoClass, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr hObject);
+#endif
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public IntPtr ProcessMemoryLimit;
+            public IntPtr JobMemoryLimit;
+            public IntPtr PeakProcessMemoryUsed;
+            public IntPtr PeakJobMemoryUsed;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public UInt64 ReadOperationCount;
+            public UInt64 WriteOperationCount;
+            public UInt64 OtherOperationCount;
+            public UInt64 ReadTransferCount;
+            public UInt64 WriteTransferCount;
+            public UInt64 OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public Int64 PerProcessUserTimeLimit;
+            public Int64 PerJobUserTimeLimit;
+            public JOB_OBJECT_LIMIT LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public UInt32 ActiveProcessLimit;
+            public IntPtr Affinity;
+            public UInt32 PriorityClass;
+            public UInt32 SchedulingClass;
+        }
+
+        [Flags]
+        private enum JOB_OBJECT_LIMIT : uint
+        {
+            KILL_ON_JOB_CLOSE = 0x2000
+        }
+
+        private enum JOB_OBJECT_INFO_CLASS
+        {
+            ExtendedLimitInformation = 9
+        }
+    }
+
+}

--- a/testEnvironments.json
+++ b/testEnvironments.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1",
   "environments": [
     // See https://aka.ms/remotetesting for more details
@@ -9,9 +9,9 @@
       "wslDistribution": "Ubuntu"
     },
     {
-      "name": "Docker dotnet/sdk",
+      "name": "Docker dotnet/sdk:8.0",
       "type": "docker",
-      "dockerImage": "mcr.microsoft.com/dotnet/sdk"
+      "dockerImage": "mcr.microsoft.com/dotnet/sdk:8.0"
     }
   ]
 }


### PR DESCRIPTION
Make sure unit tests run with all of the following:

* dotnet test (--arch=....)
* vstest.console.exe
* inside docker container
* from VS
  * WSL
  * Local

Additionally

* Use Win32 JobObjects to ensure LCTargeTest processes are *really* terminated when `testhost.exe` exits.
* Add .github/workflows to Solution
* Reorganize and cleanup tests
* Use UnitTestOutcome.NotRun instead of UnitTestOutcome.Passed when a test doesn't match the current platform